### PR TITLE
feat: add codename for Realme C33

### DIFF
--- a/data.json
+++ b/data.json
@@ -48,6 +48,7 @@
     "even/RMX3195/RMX3197": "Realme C25s",
     "RMX3265/RMX3268/RMX3269": "Realme C25Y",
     "RMX3501": "Realme C31",
+    "RMX3624/RMX3627": "Realme C33",
     "nicky/RMX3511": "Realme C35",
     "hulk/RMX3760": "Realme C53",
     "miami/RMX3710": "Realme C55"


### PR DESCRIPTION
There are two versions of this model RMX3624 for the base model and RMX3627 for the 128GB model. I am currently using the 128GB model. 